### PR TITLE
Update to lts-13.2/GHC 8.6

### DIFF
--- a/generate_docs.sh
+++ b/generate_docs.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+stack haddock --haddock-arguments "--odir=./docs/haddocks"

--- a/src/Mirza/BusinessRegistry/Main.hs
+++ b/src/Mirza/BusinessRegistry/Main.hs
@@ -18,6 +18,7 @@ import           Mirza.Common.Utils                      (randomText)
 
 import           Data.GS1.EPC                            (GS1CompanyPrefix (..))
 
+import           Servant
 import           Servant.Swagger.UI
 
 import qualified Data.Pool                               as Pool

--- a/src/Mirza/BusinessRegistry/Main.hs
+++ b/src/Mirza/BusinessRegistry/Main.hs
@@ -18,7 +18,6 @@ import           Mirza.Common.Utils                      (randomText)
 
 import           Data.GS1.EPC                            (GS1CompanyPrefix (..))
 
-import           Servant                                 hiding (header)
 import           Servant.Swagger.UI
 
 import qualified Data.Pool                               as Pool

--- a/src/Mirza/SupplyChain/Main.hs
+++ b/src/Mirza/SupplyChain/Main.hs
@@ -13,6 +13,7 @@ import           Mirza.SupplyChain.Types            (AppError, EnvType (..),
 
 import qualified Mirza.SupplyChain.Types            as ST
 
+import           Servant
 import           Servant.Client
 import           Servant.Swagger.UI
 

--- a/src/Mirza/SupplyChain/Main.hs
+++ b/src/Mirza/SupplyChain/Main.hs
@@ -13,7 +13,6 @@ import           Mirza.SupplyChain.Types            (AppError, EnvType (..),
 
 import qualified Mirza.SupplyChain.Types            as ST
 
-import           Servant                            hiding (header)
 import           Servant.Client
 import           Servant.Swagger.UI
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,7 @@ packages:
 - '.'
 - location:
     git: https://github.com/tathougies/beam.git
-    commit: 01bbb89c03b93daa2500877a511159df9d91002a # Head on 2018-07-02
+    commit: 2489a213cdee6341de46a3aa015c35067f4d6076 # Head on 2019-01-10
   extra-dep: true
   subdirs:
     - beam-core
@@ -12,15 +12,12 @@ packages:
 extra-deps:
 - git: https://github.com/data61/GS1Combinators.git
   commit: 8f8db19236dc745426c4f36a2169eba250c4355f
-- Unique-0.4.7.5@sha256:580b578ddde452111cc20aa84bdccd7e723d19eb4f8d167d2358d08a4637eed3
+- git: git@github.com:kapralVV/Unique.git
+  commit: 8b543fd9c9f9e3909875942098a47df19a68c9da  # Head on 2019-01-10
 - servant-flatten-0.2
-- hspec-2.5.0
-- hspec-core-2.5.0
-- hspec-discover-2.5.0
-- katip-0.5.5.0
 - hoist-error-0.2.1.0
 
-resolver: lts-12.0
+resolver: lts-13.2
 # allow-newer: true
 ghc-options:
   $locals: -Wall

--- a/test/Mirza/Common/Tests/ServantUtils.hs
+++ b/test/Mirza/Common/Tests/ServantUtils.hs
@@ -31,12 +31,19 @@ endWaiApp (thread, _) = killThread thread
 
 openTestSocket :: IO (Port, Socket)
 openTestSocket = do
-  s <- socket AF_INET Stream defaultProtocol
-  localhost <- inet_addr "127.0.0.1"
-  bind s (SockAddrInet aNY_PORT localhost)
+  addr:_ <- getAddrInfo
+              (Just $ defaultHints { addrFamily = AF_INET
+                                   , addrSocketType = Stream
+                                   })
+              (Just "127.0.0.1")
+              Nothing
+  
+  s <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
+  bind s (addrAddress addr)
   listen s 1
   prt <- socketPort s
   pure (fromIntegral prt, s)
+
 
 {-# NOINLINE manager' #-}
 manager' :: C.Manager

--- a/test/Mirza/Common/Tests/Utils.hs
+++ b/test/Mirza/Common/Tests/Utils.hs
@@ -12,6 +12,9 @@ module Mirza.Common.Tests.Utils
   , databaseNameToConnectionString
   , makeDatabase
   , dropTables
+
+  , expectJust
+  , expectRight
   )
   where
 
@@ -24,6 +27,7 @@ import           Text.Email.Validate     (EmailAddress, emailAddress)
 
 import           Test.Hspec.Expectations (Expectation, shouldSatisfy)
 
+import           Data.Either             (fromRight)
 import           Data.Foldable           (forM_)
 import           Data.String             (fromString)
 import qualified Data.Text               as T (unpack)
@@ -159,3 +163,16 @@ dropTables db conn = do
   --       investigating.
   void $ forM_ tables $ \tableName -> do
     execute_ conn $ fromString $ T.unpack $ "DROP TABLE IF EXISTS " <> tableName <> ";"
+
+-- GHC 8.6.x enabled MonadFailDesugaring by default, which means that if we're being lazy and
+-- using incomplete pattern matches in a Monad which does have an instance for MonadFail
+-- the code will will fail to compile. An example monad is the servant ClientM, therefore
+-- expectJust/expectRight should be used when writing test code that expects either a Just/Right.
+
+-- | Like fromJust from Data.Maybe except an error is thrown WITH a stacktrace
+expectJust :: Maybe a -> a
+expectJust = maybe (error "Expected: Just a") id
+
+-- | Returns b if Right, otherwise calls error
+expectRight :: Either a b -> b
+expectRight = fromRight (error "Expected: Right b")

--- a/test/Mirza/SupplyChain/Tests/Utils.hs
+++ b/test/Mirza/SupplyChain/Tests/Utils.hs
@@ -39,6 +39,7 @@ import           Crypto.JOSE.Types                     (Base64Octets (..))
 import           Mirza.BusinessRegistry.Tests.Generate (genMultipleUsersBR)
 import           Mirza.SupplyChain.Tests.Generate
 
+import            Mirza.Common.Tests.Utils             (expectJust, expectRight)
 import           Mirza.BusinessRegistry.Tests.Utils    (readJWK)
 
 import           Data.Maybe                            (fromJust)
@@ -100,11 +101,11 @@ insertAndAuth scsUrl brUrl auth locMap ht (entity:entities) = do
       [newUserSCS] = genMultipleUsersSCS "citrusTest" 1 [name] [companyPrefix]
       [newUserBR] = genMultipleUsersBR "citrusTest" 1 [name] [companyPrefix]
       newBiz = BT.NewBusiness companyPrefix bizName
-  Just pubKey <- liftIO $ readJWK pubKeyPath
-  Right insertedUserIdSCS <- httpSCS $ SCSClient.addUser newUserSCS
+  pubKey <- fmap expectJust $ liftIO $ readJWK pubKeyPath
+  insertedUserIdSCS <- fmap expectRight $ httpSCS $ SCSClient.addUser newUserSCS
   _insertedUserIdBR <- httpBR $ BRClient.addUser auth newUserBR
   _insertedPrefix <- httpBR $ BRClient.addBusiness auth newBiz
-  Right brKeyId <- httpBR $ BRClient.addPublicKey auth pubKey Nothing
+  brKeyId <- fmap expectRight $ httpBR $ BRClient.addPublicKey auth pubKey Nothing
   let basicAuthDataSCS =
         BasicAuthData
           (toByteString . ST.newUserEmailAddress $ newUserSCS)
@@ -121,7 +122,7 @@ insertAndAuth scsUrl brUrl auth locMap ht (entity:entities) = do
 insertEachEvent :: AuthHash -> EachEvent ->  ClientM ()
 insertEachEvent _ (EachEvent [] _) = pure ()
 insertEachEvent ht (EachEvent (initialEntity: entities) ev) = do
-  let Just (entityUserId, auth, _) = H.lookup initialEntity ht
+  let (entityUserId, auth, _) = expectJust $ H.lookup initialEntity ht
   (insertedEventInfo, _eventId) <- case _etype ev of
           AggregationEventT -> SCSClient.insertAggEvent auth (fromJust $ mkAggEvent ev)
           ObjectEventT -> SCSClient.insertObjectEvent auth (fromJust $ mkObjectEvent ev)
@@ -133,17 +134,16 @@ insertEachEvent ht (EachEvent (initialEntity: entities) ev) = do
 
 clientSignEvent :: AuthHash -> EventInfo -> Entity -> ClientM EventInfo
 clientSignEvent ht evInfo entity = do
-  let Just (_, auth, _) = H.lookup entity ht
+  let (_, auth, _) = expectJust $ H.lookup entity ht
       (EventInfo event _ _ (Base64Octets toSign) _) = evInfo
       eventId = fromJust $ _eid event
       (Entity _ _ _ _ (KeyPairPaths privKeyPath pubKeyPath)) = entity
-  Just privKey <- liftIO $ readJWK privKeyPath
-  Just pubKey <- liftIO $ readJWK pubKeyPath
+  privKey <- fmap expectJust $ liftIO $ readJWK privKeyPath
+  pubKey <- fmap expectJust $ liftIO $ readJWK pubKeyPath
   keyId <- BRClient.addPublicKey auth pubKey Nothing
 
-  Right mySig <- liftIO $ runExceptT @JOSE.Error (
+  s <- liftIO $ runExceptT @JOSE.Error (
           signJWS toSign (Identity (newJWSHeader ((), RS256), privKey))
           )
-  let signedEvent = SignedEvent eventId keyId mySig
-  eventSign auth signedEvent
+  eventSign auth . SignedEvent eventId keyId . expectRight $ s
 


### PR DESCRIPTION
- Update beam/Unique to HEAD commit
- Fixed errors caused by MonadFailDesugaring being enabled by default
- Remove use of deprecated Network functions in ServantUtils.hs