### PR TITLE
Optimize ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ services:
 # Caching so the next build will be fast too.
 cache:
   directories:
-  - $HOME/.stack
+  - .stack
   - .stack-work
 
 # Ensure necessary system libraries are present

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ services:
 cache:
   directories:
   - $HOME/.stack
-  - .stack
   - .stack-work
 
 # Ensure necessary system libraries are present

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@
 # Choose a build environment
 dist: xenial
 
+cache:
+  timeout: 4000
+
 # Do not choose a language; we provide our own build tools.
 language: generic
 
@@ -20,6 +23,7 @@ services:
 # Caching so the next build will be fast too.
 cache:
   directories:
+  - $HOME/.stack
   - .stack
   - .stack-work
 


### PR DESCRIPTION
- Adds a timeout for cache storage (the default was 1000)

Now GHC and the LTS build plan don't get installed every time :slightly_smiling_face: 
