### PR TITLE
Add a commandline option to allow bootstrapping users into the database.

### DIFF
--- a/Mirza.cabal
+++ b/Mirza.cabal
@@ -63,6 +63,7 @@ library
   build-depends:      base >= 4.7 && < 5
                     , GS1Combinators
                     , aeson
+                    , attoparsec
                     , base64-bytestring
                     , beam-core
                     , beam-migrate

--- a/src/Mirza/BusinessRegistry/Main.hs
+++ b/src/Mirza/BusinessRegistry/Main.hs
@@ -468,11 +468,10 @@ parsedServerOptions = ServerOptionsBR
 initDb :: Parser ExecMode
 initDb = pure InitDb
 
-populateDb :: Parser ExecMode
-populateDb = pure PopulateDatabase
 
 userCommand :: Parser ExecMode
 userCommand = UserAction <$> userCommands
+
 
 userCommands :: Parser UserCommand
 userCommands = subparser
@@ -518,6 +517,10 @@ businessList = pure BusinessList
 
 bootstrap :: Parser ExecMode
 bootstrap = Bootstrap <$> emailParser <*> passwordParser <*> companyPrefixParser
+
+
+populateDb :: Parser ExecMode
+populateDb = pure PopulateDatabase
 
 
 emailParser :: Parser EmailAddress


### PR DESCRIPTION
I think that this deals with this requirement. I don't love the way that it works for the following reasons:
1) I thought about the tradeoff of taking all of the business / user fields (i.e. name / phone number) or just those that we really care about. In the end I decided to just go with the minimum necessary. While it would look cleaner from our end, and possibly provide something that had additional purposes in the future, I decided on the minimum required for this feature for now, just to simplify devops lives so that they didn't need to store and pass around a bunch of bogus additional data.
2) That the user / business information is incomplete and suggests that the model is broken. I.e. either the model should be changed so that the fields that aren't accurately populated are made into Maybe fields (i.e. even the business component of the user...i.e. its probably reasonable that there are different types of users...users associated with businesses and users that have access to the system). But for now this solution works with the exisiting data model, and we really need to dig deeper into user requirements to understand how this should work properly.
3) Each of the username, password, company prefix aren't named in the command call, which could mean that they are subbed in in the wrong order by mistake. In practice hopefully this should be detected fairly quickly...i..e. a user with these credentials can't log in. But does make it slightly error prone. But have chosen this to make invocation less verbose.
4) Don't like the name bootstrap for this option....but also can't think of anything better.


Any feedback welcome, but I think that this is the best set of compromises that I could come up with for the incomplete state that we are in atm.