### PR TITLE
Add license check to CI pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ script:
 # Build the package, its tests, and its docs and run the tests
 - stack clean
 - stack --no-terminal build --copy-bins
+- stack ls dependencies --license | ./license_check.py
 - psql -c 'CREATE DATABASE testsupplychainserver;' -U postgres
 - psql -c 'CREATE DATABASE testbusinessregistry;' -U postgres
 - stack exec supplyChainServer -- --init-db -c 'dbname=testsupplychainserver'

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,5 +59,5 @@ script:
 - psql -c 'CREATE DATABASE testbusinessregistry;' -U postgres
 - stack exec supplyChainServer -- --init-db -c 'dbname=testsupplychainserver'
 - echo 'YES' | stack exec businessRegistry -- initdb -c 'dbname=testbusinessregistry'
-- ./run_tests.sh --no-terminal
+- stack test --ta -j1
 - if [ "$TRAVIS_BRANCH" == "master" ]; then source deploy/deploy.sh; fi


### PR DESCRIPTION
- Completes #324 
- Stops the pipeline from building the code twice. Previously it was building once for `stack build` and then again for running the tests (since the optimisation flags were different. Now it just runs the tests with the compiled code from the build.