### PR TITLE
Traversal down a supply chain

### DIFF
--- a/src/Mirza/SupplyChain/Handlers/UXUtils.hs
+++ b/src/Mirza/SupplyChain/Handlers/UXUtils.hs
@@ -39,6 +39,7 @@ import           Data.Aeson
 
 import           Data.Swagger                          (ToSchema (..))
 
+import           Data.Either                           (either)
 import           Data.List                             (nub, sortOn)
 
 data PrettyEventResponse =
@@ -71,10 +72,7 @@ listEventsPretty  :: (Member context '[HasDB, HasBRClientEnv],
                   => ST.User
                   -> LabelEPCUrn
                   -> AppM context err [PrettyEventResponse]
-listEventsPretty _user lblUrn = do
-  case urn2LabelEPC . getLabelEPCUrn $ lblUrn of
-    Left err  -> throwParseError err
-    Right lbl -> fetchPrettyEvents lbl
+listEventsPretty _user = either throwParseError fetchPrettyEvents . urn2LabelEPC . getLabelEPCUrn
 
 fetchPrettyEvents :: (Member context '[HasDB, HasBRClientEnv],
                     Member err     '[AsServiceError, AsServantError, AsSqlError, BT.AsBRError])

--- a/src/Mirza/SupplyChain/Handlers/UXUtils.hs
+++ b/src/Mirza/SupplyChain/Handlers/UXUtils.hs
@@ -39,7 +39,7 @@ import           Data.Aeson
 
 import           Data.Swagger                          (ToSchema (..))
 
-import           Data.List                             (sortOn)
+import           Data.List                             (nub, sortOn)
 
 data PrettyEventResponse =
   PrettyEventResponse
@@ -85,7 +85,7 @@ fetchPrettyEvents lbl = do
   currEvs <- traverse eventToPrettyEvent evs
   (pEvs :: [PrettyEventResponse] ) <- concat <$> traverse getParentEvents evs
   let allEvs = currEvs <> pEvs
-  pure $ sortOn ( _eventTime . Ev._when . prettyEvent) allEvs
+  pure $ sortOn ( _eventTime . Ev._when . prettyEvent) $ nub allEvs
 
 
 getParentEvents :: (Member context '[HasDB, HasBRClientEnv],

--- a/src/Mirza/SupplyChain/Handlers/UXUtils.hs
+++ b/src/Mirza/SupplyChain/Handlers/UXUtils.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 
 module Mirza.SupplyChain.Handlers.UXUtils
   (
@@ -17,6 +18,7 @@ import           Mirza.Common.GS1BeamOrphans           (LabelEPCUrn (..))
 import           Mirza.SupplyChain.Handlers.Queries    (listEventsQuery)
 
 import           Mirza.SupplyChain.ErrorUtils          (throwParseError)
+import           Mirza.SupplyChain.EventUtils          (getParent)
 import           Mirza.SupplyChain.Types               hiding (NewUser (..),
                                                         User (..))
 import qualified Mirza.SupplyChain.Types               as ST
@@ -25,7 +27,8 @@ import           Mirza.BusinessRegistry.Types          (BusinessAndLocationRespo
                                                         BusinessResponse (..))
 import qualified Mirza.BusinessRegistry.Types          as BT
 
-import           Data.GS1.DWhat                        (urn2LabelEPC)
+import           Data.GS1.DWhat
+import           Data.GS1.DWhen                        (DWhen (..))
 import           Data.GS1.DWhere
 import           Data.GS1.EPC
 import qualified Data.GS1.Event                        as Ev
@@ -35,6 +38,8 @@ import           Mirza.BusinessRegistry.Client.Servant (uxLocationByGLN)
 import           Data.Aeson
 
 import           Data.Swagger                          (ToSchema (..))
+
+import           Data.List                             (sortOn)
 
 data PrettyEventResponse =
   PrettyEventResponse
@@ -68,16 +73,37 @@ listEventsPretty  :: (Member context '[HasDB, HasBRClientEnv],
                   -> AppM context err [PrettyEventResponse]
 listEventsPretty _user lblUrn = do
   case urn2LabelEPC . getLabelEPCUrn $ lblUrn of
-    Left err -> throwParseError err
-    Right lbl -> do
-      evs <- runDb $ listEventsQuery lbl
-      traverse func evs
+    Left err  -> throwParseError err
+    Right lbl -> fetchPrettyEvents lbl
+
+fetchPrettyEvents :: (Member context '[HasDB, HasBRClientEnv],
+                    Member err     '[AsServiceError, AsServantError, AsSqlError, BT.AsBRError])
+                  => LabelEPC
+                  -> AppM context err [PrettyEventResponse]
+fetchPrettyEvents lbl = do
+  evs <- runDb $ listEventsQuery lbl
+  currEvs <- traverse eventToPrettyEvent evs
+  (pEvs :: [PrettyEventResponse] ) <- concat <$> traverse getParentEvents evs
+  let allEvs = currEvs <> pEvs
+  pure $ sortOn ( _eventTime . Ev._when . prettyEvent) allEvs
 
 
-func :: (Member context '[HasDB, HasBRClientEnv],
-         Member err     '[AsServiceError, AsServantError, AsSqlError, BT.AsBRError])
-      => Ev.Event -> AppM context err PrettyEventResponse
-func ev = do
+getParentEvents :: (Member context '[HasDB, HasBRClientEnv],
+                    Member err     '[AsServiceError, AsServantError, AsSqlError, BT.AsBRError])
+                => Ev.Event
+                -> AppM context err [PrettyEventResponse]
+getParentEvents ev = do
+  let mParentLabel = getParent . Ev._what $ ev
+  case mParentLabel of
+    Nothing              -> pure []
+    Just (ParentLabel p) -> fetchPrettyEvents (IL p)
+
+
+eventToPrettyEvent :: (Member context '[HasDB, HasBRClientEnv],
+                       Member err     '[AsServiceError, AsServantError, AsSqlError, BT.AsBRError])
+                   => Ev.Event
+                   -> AppM context err PrettyEventResponse
+eventToPrettyEvent ev = do
   let mloc = _readPoint . Ev._where $ ev
   case mloc of
     Nothing -> throwing BT._LocationNotKnownBRE ()


### PR DESCRIPTION
- When searching for a label, it also searches for the parent labels
- Does *not* search for child labels
- Sorts the events by their record time. Only one from Duplicate events (e.g, two labels have the same parent) is returned