### PR TITLE
Make database timezone agnostic

### DIFF
--- a/restart.sh
+++ b/restart.sh
@@ -23,36 +23,7 @@ fi
 
 stack build --fast
 stack exec supplyChainServer -- --init-db --brhost localhost --brport 8200
-stack exec businessRegistry -- initdb
-
-# eventuially, we will get an updated list from ASIC and populate the db
-# TODO: Update or delete this section. This is out of date.
-echo "Now inserting some dummy companies"
-echo
-psql \
-    -X \
-    --echo-all \
-    --set AUTOCOMMIT=on \
-    --set ON_ERROR_STOP=on \
-    $BR_DBNAME \
-    << EOF
-INSERT INTO businesses \
-    (biz_gs1_company_prefix, biz_name, biz_function, biz_site_name, biz_address, biz_lat, biz_long) \
-    VALUES \
-    ('4012345', 'Lomondo', 'Truck-driver', 'Holsworthy', '123 Holsworthy St', 123.456, 89.034);
-
-INSERT INTO businesses \
-    (biz_gs1_company_prefix, biz_name, biz_function, biz_site_name, biz_address) \
-    VALUES \
-    ('4000001', 'Manny''s Olive Oil', 'Farmenter', 'Warwick Farm', 'Farmland Av');
-
-INSERT INTO businesses \
-    (biz_gs1_company_prefix, biz_name, biz_function, biz_site_name, biz_address) \
-    VALUES \
-    ('0614141', 'Pulitzer Harvest', 'Harvester', 'Keskuskatu', 'ul. Filtrowa 68');
-EOF
-
-echo "Done"
+echo 'YES' | stack exec businessRegistry -- initdb
 
 export START_IN=2
 echo "Starting the server in $START_IN s. Feed me a SIGINT (CTRL+C or equivalent) to stop."

--- a/src/Mirza/BusinessRegistry/Database/Schema/V0001.hs
+++ b/src/Mirza/BusinessRegistry/Database/Schema/V0001.hs
@@ -80,10 +80,10 @@ migration () =
           (field "key_id" pkSerialType)
           (UserId $ field "key_user_id" pkSerialType)
           (field "jwk" json notNull)
-          (field "creation_time" timestamptz)
-          (field "revocation_time" (maybeType timestamptz))
+          (field "creation_time" timestamp)
+          (field "revocation_time" (maybeType timestamp))
           (UserId $ field "revoking_user_id" (maybeType pkSerialType))
-          (field "expiration_time" (maybeType timestamptz))
+          (field "expiration_time" (maybeType timestamp))
           lastUpdateField
           )
 

--- a/src/Mirza/Common/Beam.hs
+++ b/src/Mirza/Common/Beam.hs
@@ -44,7 +44,7 @@ textType = BMigrate.DataType pgTextType
 
 -- | Field definition to use for last updated columns
 lastUpdateField :: BMigrate.TableFieldSchema PgColumnSchemaSyntax (Maybe LocalTime)
-lastUpdateField = field "last_update" (maybeType timestamptz) (defaultTo_ (B.just_ now_))
+lastUpdateField = field "last_update" (maybeType timestamp) (defaultTo_ (B.just_ now_))
 
 -- | Helper function to manage the returnValue of ``readMaybe`` or gracefully
 -- fail

--- a/src/Mirza/Common/Utils.hs
+++ b/src/Mirza/Common/Utils.hs
@@ -147,7 +147,7 @@ addLastUpdateTriggers db = forM_ (getTableNames db) $ \tName -> do
   liftIO $ execute_ conn $ fromString $ unpack $
     "CREATE OR REPLACE FUNCTION sync_lastmod() RETURNS trigger AS $$ \
       \BEGIN \
-        \NEW.last_update := NOW(); \
+        \NEW.last_update := NOW() AT TIME ZONE 'UTC'; \
         \RETURN NEW; \
       \END; \
       \$$ LANGUAGE plpgsql; \

--- a/src/Mirza/SupplyChain/Database/Schema/V0001.hs
+++ b/src/Mirza/SupplyChain/Database/Schema/V0001.hs
@@ -193,8 +193,8 @@ migration () =
     <*> createTable "whens" ( When
           lastUpdateField
           (field "when_id" pkSerialType)
-          (field "when_event_time" timestamptz notNull)
-          (field "when_record_time" (maybeType timestamptz))
+          (field "when_event_time" timestamp notNull)
+          (field "when_record_time" (maybeType timestamp))
           (field "when_time_zone" (varchar (Just maxTimeZoneLength)) notNull)
           (EventId $ field "when_event_id" pkSerialType (defaultFkConstraint "events" ["event_id"]))
     )
@@ -221,7 +221,7 @@ migration () =
           (EventId $ field "signature_event_id" pkSerialType notNull (defaultFkConstraint "events" ["event_id"]))
           (field "signature_key_id" brKeyIdType notNull)
           (field "signature_signature" json notNull)
-          (field "signature_timestamp" timestamptz notNull)
+          (field "signature_timestamp" timestamp notNull)
     )
     <*> createTable "hashes" ( Hashes
           lastUpdateField

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@ extra-deps:
 - servant-flatten-0.2
 - hoist-error-0.2.1.0
 
-resolver: lts-13.9
+resolver: lts-13.11
 # allow-newer: true
 ghc-options:
   $locals: -Wall


### PR DESCRIPTION
Closes #352 
PG converts `LocalTime` to `UTCTime` based on the system's timezone, and we also convert any time to `UTCTime`, so there is a double conversion. Switching to `TIMESTAMP WITHOUT TIME ZONE` to get around this.