### PR TITLE
Adapt SCS migration to use last_update triggers

### DIFF
--- a/src/Mirza/SupplyChain/Database/Migrate.hs
+++ b/src/Mirza/SupplyChain/Database/Migrate.hs
@@ -16,6 +16,9 @@ import           Mirza.SupplyChain.Database.Schema       (supplyChainDb)
 import qualified Control.Exception                       as E
 import           Control.Monad                           (void)
 
+import           System.Exit                             (exitFailure)
+import           System.IO                               (hPutStrLn, stderr)
+
 import           Data.ByteString.Char8                   (ByteString)
 import           Database.Beam                           (withDatabase,
                                                           withDatabaseDebug)
@@ -47,7 +50,9 @@ tryCreateSchema :: Bool -> Connection -> IO ()
 tryCreateSchema runSilently conn = E.catch (createSchema runSilently conn) handleErr
   where
     handleErr :: SqlError -> IO ()
-    handleErr err = putStrLn $ "XXXXXX " <> show err <> " XXXXXX"
+    handleErr err = do
+      hPutStrLn stderr $ "Migration failed with error:  " <> show err
+      exitFailure
 
 migrate :: (Member context '[HasLogging, HasDB])
         => context -> ByteString -> IO ()

--- a/src/Mirza/SupplyChain/Database/Schema.hs
+++ b/src/Mirza/SupplyChain/Database/Schema.hs
@@ -8,7 +8,7 @@ module Mirza.SupplyChain.Database.Schema
 
 import           Database.Beam                           (DatabaseSettings)
 import           Database.Beam                           as B
-import           Database.Beam.Migrate.Types             hiding (migrateScript)
+import           Database.Beam.Migrate.Types
 import           Database.Beam.Postgres                  (PgCommandSyntax,
                                                           Postgres)
 import           Database.Beam.Schema.Tables             (primaryKey)


### PR DESCRIPTION
Adds `last_update` triggers to the Supply Chain Server database when migration is run.