### PR TITLE
Generalise event

### DIFF
--- a/projects/br_scs/Mirza.cabal
+++ b/projects/br_scs/Mirza.cabal
@@ -64,7 +64,6 @@ library
                     , GS1Combinators
                     , aeson
                     , attoparsec
-                    , base64-bytestring
                     , beam-core
                     , beam-migrate
                     , beam-postgres
@@ -94,7 +93,6 @@ library
                     , text
                     , time
                     , transformers >= 0.4
-                    , Unique
                     , uuid
                     , uuid-types
                     , wai
@@ -138,25 +136,20 @@ test-suite supplyChainServer-test
                     , Mirza.BusinessRegistry.Tests.Utils
   default-extensions:  OverloadedStrings
   build-depends:       base
-                     , base64-bytestring
                      , GS1Combinators
                      , Mirza
                      , resource-pool >= 0.2.3
                      , beam-core
                      , beam-postgres
                      , bytestring
-                     , email-validate
                      , hspec
                      , hspec-core
-                     , http-client
                      , mtl
                      , network
-                     , network-uri
                      , postgresql-simple
                      , process
                      , servant
                      , servant-auth-client
-                     , servant-server
                      , text
                      , time
                      , uuid
@@ -165,15 +158,12 @@ test-suite supplyChainServer-test
                      , tasty-hunit
                      , transformers
                      , hspec-expectations
-                     , unordered-containers
-                     , hashable
                      , wai
                      , warp
                      , servant-client
                      , katip
                      , temporary
                      , jose
-                     , aeson
   default-language:    Haskell2010
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -Werror
 

--- a/projects/br_scs/src/Mirza/SupplyChain/API.hs
+++ b/projects/br_scs/src/Mirza/SupplyChain/API.hs
@@ -59,17 +59,7 @@ type ServerAPI =
   --                 :> Capture "userId" UserId
   --                 :> Get '[JSON] [Ev.Event]
 -- Event Registration
-  :<|> "event"    :> "objectEvent"
-                  :> ReqBody '[JSON] ObjectEvent
-                  :> Post '[JSON] (EventInfo, Schema.EventId)
-  :<|> "event"    :> "aggregateEvent"
-                  :> ReqBody '[JSON] AggregationEvent
-                  :> Post '[JSON] (EventInfo, Schema.EventId)
-  :<|> "event"    :> "transactionEvent"
-                  :> ReqBody '[JSON] TransactionEvent
-                  :> Post '[JSON] (EventInfo, Schema.EventId)
-  :<|> "event"    :> "transformationEvent"
-                  :> ReqBody '[JSON] TransformationEvent
+  :<|> "event"    :> ReqBody '[JSON] Ev.Event
                   :> Post '[JSON] (EventInfo, Schema.EventId)
   -- UI
   :<|> "prototype" :> "list" :> "events"

--- a/projects/br_scs/src/Mirza/SupplyChain/Client/Servant.hs
+++ b/projects/br_scs/src/Mirza/SupplyChain/Client/Servant.hs
@@ -24,18 +24,16 @@ import qualified Data.GS1.Event                     as Ev
 import           Data.GS1.EventId
 
 -- * Public API
-health       :: ClientM HealthResponse
-versionInfo  :: ClientM String
+health      :: ClientM HealthResponse
+versionInfo :: ClientM String
 
 -- * Authenticated API
-eventSign           :: SignedEvent -> ClientM EventInfo
 
-listEvents          :: LabelEPCUrn -> ClientM [Ev.Event]
-eventInfo           :: EventId -> ClientM EventInfo
-
+eventSign        :: SignedEvent -> ClientM EventInfo
+listEvents       :: LabelEPCUrn -> ClientM [Ev.Event]
+eventInfo        :: EventId -> ClientM EventInfo
 insertGS1Event   :: Ev.Event -> ClientM (EventInfo, Schema.EventId)
-
-listEventsPretty    :: LabelEPCUrn -> ClientM [PrettyEventResponse]
+listEventsPretty :: LabelEPCUrn -> ClientM [PrettyEventResponse]
 
 _api     :: Client ClientM ServerAPI
 _api@(   health

--- a/projects/br_scs/src/Mirza/SupplyChain/Client/Servant.hs
+++ b/projects/br_scs/src/Mirza/SupplyChain/Client/Servant.hs
@@ -4,10 +4,7 @@ module Mirza.SupplyChain.Client.Servant
   , eventSign
   , listEvents
   , eventInfo
-  , insertObjectEvent
-  , insertAggEvent
-  , insertTransactEvent
-  , insertTransfEvent
+  , insertGS1Event
   , listEventsPretty
   ) where
 
@@ -36,10 +33,7 @@ eventSign           :: SignedEvent -> ClientM EventInfo
 listEvents          :: LabelEPCUrn -> ClientM [Ev.Event]
 eventInfo           :: EventId -> ClientM EventInfo
 
-insertObjectEvent   :: ObjectEvent -> ClientM (EventInfo, Schema.EventId)
-insertAggEvent      :: AggregationEvent -> ClientM (EventInfo, Schema.EventId)
-insertTransactEvent :: TransactionEvent -> ClientM (EventInfo, Schema.EventId)
-insertTransfEvent   :: TransformationEvent -> ClientM (EventInfo, Schema.EventId)
+insertGS1Event   :: Ev.Event -> ClientM (EventInfo, Schema.EventId)
 
 listEventsPretty    :: LabelEPCUrn -> ClientM [PrettyEventResponse]
 
@@ -52,10 +46,7 @@ _api@(   health
     :<|> listEvents
     :<|> eventInfo
 
-    :<|> insertObjectEvent
-    :<|> insertAggEvent
-    :<|> insertTransactEvent
-    :<|> insertTransfEvent
+    :<|> insertGS1Event
 
     :<|> listEventsPretty
   ) = client (Proxy :: Proxy ServerAPI)

--- a/projects/br_scs/src/Mirza/SupplyChain/EventUtils.hs
+++ b/projects/br_scs/src/Mirza/SupplyChain/EventUtils.hs
@@ -24,8 +24,10 @@ import qualified Data.GS1.Event                    as Ev
 import qualified Data.GS1.EventId                  as EvId
 
 import           Data.GS1.DWhat                    (AggregationDWhat (..),
-                                                    DWhat (..), LabelEPC (..),
+                                                    DWhat (..), InputEPC (..),
+                                                    LabelEPC (..),
                                                     ObjectDWhat (..),
+                                                    OutputEPC (..),
                                                     ParentLabel (..),
                                                     TransactionDWhat (..),
                                                     TransformationDWhat (..))
@@ -37,7 +39,8 @@ import           Data.GS1.DWhere                   (BizLocation (..),
                                                     SourceLocation (..))
 import           Data.GS1.DWhy                     (DWhy (..))
 
-import           Data.Maybe                        (catMaybes, listToMaybe)
+import           Data.Maybe                        (catMaybes, listToMaybe,
+                                                    maybeToList)
 
 import           Data.ByteString                   (ByteString)
 import qualified Data.Text                         as T
@@ -221,7 +224,10 @@ toStorageDWhen (Schema.WhenId pKey) (DWhen eventTime mRecordTime tZone) =
     (T.pack . timeZoneOffsetString $ tZone)
 
 getLabels :: DWhat -> [LabelEPC]
-getLabels = undefined
+getLabels (ObjWhat (ObjectDWhat _act epcList)) = epcList
+getLabels (AggWhat (AggregationDWhat _act mParent childEpcList)) = childEpcList <> maybeToList (IL . unParentLabel <$> mParent)
+getLabels (TransactWhat (TransactionDWhat _act mParent _bizT epcList)) = epcList <> maybeToList (IL . unParentLabel <$> mParent)
+getLabels (TransformWhat (TransformationDWhat _tId input output)) = (unInputEPC <$> input) <> (unOutputEPC <$> output)
 
 
 toStorageDWhy :: Schema.WhyId -> DWhy -> Schema.EventId -> Schema.Why

--- a/projects/br_scs/src/Mirza/SupplyChain/EventUtils.hs
+++ b/projects/br_scs/src/Mirza/SupplyChain/EventUtils.hs
@@ -5,7 +5,7 @@ module Mirza.SupplyChain.EventUtils
   , insertDWhat, insertDWhen, insertDWhere, insertDWhy
   , insertWhatLabel, insertLabelEvent, insertLabel, findInstLabelIdByUrn
   , findEvent, findSchemaEvent, getEventList
-  , findLabelId, getParent
+  , findLabelId, getParent, getLabels
   , findDWhere
   ) where
 
@@ -119,7 +119,7 @@ toStorageDWhat pKey mParentId mBizTranId eventId dwhat
         (getAction dwhat)
         (Schema.LabelId mParentId)
         (Schema.BizTransactionId mBizTranId)
-        (Schema.TransformationId $ unTransformationId <$> (getTransformationId dwhat))
+        (Schema.TransformationId $ unTransformationId <$> getTransformationId dwhat)
         eventId
 
 getTransformationId :: DWhat -> Maybe EPC.TransformationId
@@ -220,6 +220,9 @@ toStorageDWhen (Schema.WhenId pKey) (DWhen eventTime mRecordTime tZone) =
     (toDbTimestamp <$> mRecordTime)
     (T.pack . timeZoneOffsetString $ tZone)
 
+getLabels :: DWhat -> [LabelEPC]
+getLabels = undefined
+
 
 toStorageDWhy :: Schema.WhyId -> DWhy -> Schema.EventId -> Schema.Why
 toStorageDWhy (Schema.WhyId pKey) (DWhy mBiz mDisp)
@@ -258,7 +261,7 @@ insertSrcDestType :: MU.LocationField
                   -> Schema.EventId
                   -> (SourceDestType, LocationEPC)
                   -> DB context err PrimaryKeyType
-insertSrcDestType locField eventId (sdType, (SGLN pfix locationRef ext)) =
+insertSrcDestType locField eventId (sdType, SGLN pfix locationRef ext) =
   QU.withPKey $ \pKey -> do
     let stWhere = Schema.Where Nothing pKey pfix (Just sdType) locationRef locField ext eventId
     pg $ B.runInsert $ B.insert (Schema._wheres Schema.supplyChainDb)

--- a/projects/br_scs/src/Mirza/SupplyChain/Handlers/EventRegistration.hs
+++ b/projects/br_scs/src/Mirza/SupplyChain/Handlers/EventRegistration.hs
@@ -1,26 +1,23 @@
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
 
 module Mirza.SupplyChain.Handlers.EventRegistration
   ( insertGS1Event
   -- , sendToBlockchain
   ) where
 
-import qualified Mirza.Common.GS1BeamOrphans       as MU
 import           Mirza.SupplyChain.Database.Schema as Schema
 
 import           Mirza.SupplyChain.EventUtils
 import           Mirza.SupplyChain.Types
 
-import           Data.GS1.DWhat                    (LabelEPC (..))
 import           Data.GS1.Event                    as Ev
 
-insertGS1Event :: (Member context '[HasDB],
-                      Member err     '[AsSqlError])
-                  => Ev.Event
-                  -> AppM context err (EventInfo, Schema.EventId)
+insertGS1Event  :: (Member context '[HasDB],
+                    Member err     '[AsSqlError])
+                => Ev.Event
+                -> AppM context err (EventInfo, Schema.EventId)
 insertGS1Event ev = runDb $ insertEventQuery ev
 
 insertEventQuery :: Ev.Event
@@ -31,9 +28,9 @@ insertEventQuery
   -- uniqueness of the JSON event is enforced
   (evInfo, eventId) <- insertEvent event
   whatId <- insertDWhat Nothing dwhat eventId
-  let (labelWithTypes :: [LabelWithType]) = getLabelsWithType dwhat
-      (labelEpcs :: [LabelEPC]) = getLabel <$> labelWithTypes
-      (labelTypes :: [Maybe MU.LabelType]) = getLabelType <$> labelWithTypes
+  let labelWithTypes = getLabelsWithType dwhat
+      labelEpcs = getLabel <$> labelWithTypes
+      labelTypes = getLabelType <$> labelWithTypes
   labelIds' <- mapM insertLabel labelEpcs
   let labelIds = Schema.LabelId <$> labelIds'
       labelIdWithTypes = zip labelTypes labelIds

--- a/projects/br_scs/src/Mirza/SupplyChain/Handlers/EventRegistration.hs
+++ b/projects/br_scs/src/Mirza/SupplyChain/Handlers/EventRegistration.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 
 module Mirza.SupplyChain.Handlers.EventRegistration
   ( insertGS1Event
@@ -13,19 +14,8 @@ import           Mirza.SupplyChain.Database.Schema as Schema
 import           Mirza.SupplyChain.EventUtils
 import           Mirza.SupplyChain.Types
 
-import           Data.GS1.DWhat                    (AggregationDWhat (..),
-                                                    DWhat (..), InputEPC (..),
-                                                    LabelEPC (..),
-                                                    ObjectDWhat (..),
-                                                    OutputEPC (..),
-                                                    ParentLabel (..),
-                                                    TransactionDWhat (..),
-                                                    TransformationDWhat (..))
+import           Data.GS1.DWhat                    (LabelEPC (..))
 import           Data.GS1.Event                    as Ev
-
-import           Data.Maybe                        (isJust)
-
-import           Control.Monad.Except              (when)
 
 insertGS1Event :: (Member context '[HasDB],
                       Member err     '[AsSqlError])
@@ -36,189 +26,23 @@ insertGS1Event ev = runDb $ insertEventQuery ev
 insertEventQuery :: Ev.Event
                  -> DB context err (EventInfo, Schema.EventId)
 insertEventQuery
-  event@(Ev.Event
-    eType
-    foreignEventId
-    dwhat
-    dwhen
-    dwhy
-    dwhere
-  ) = do
+  event@(Ev.Event _eType _foreignEventId dwhat dwhen dwhy dwhere) = do
   -- insertEvent has to be the first thing that happens here so that
   -- uniqueness of the JSON event is enforced
   (evInfo, eventId) <- insertEvent event
   whatId <- insertDWhat Nothing dwhat eventId
-  labelIds' <- mapM insertLabel (getLabels dwhat)
-  let labelIds = Schema.LabelId <$> labelIds'
-  _whenId <- insertDWhen dwhen eventId
-  _whyId <- insertDWhy dwhy eventId
-  insertDWhere dwhere eventId
-  mapM_ (insertWhatLabel Nothing (Schema.WhatId whatId)) labelIds
-  mapM_ (insertLabelEvent Nothing eventId) labelIds
-  pure (evInfo, eventId)
-
-
-insertObjectEventQuery :: ObjectEvent
-                       -> DB context err (EventInfo, Schema.EventId)
-insertObjectEventQuery
-  (ObjectEvent
-    foreignEventId
-    act
-    labelEpcs
-    dwhen dwhy dwhere
-  ) = do
-  let
-      dwhat =  ObjWhat $ ObjectDWhat act labelEpcs
-      event = Ev.Event Ev.ObjectEventT foreignEventId dwhat dwhen dwhy dwhere
-
-  -- insertEvent has to be the first thing that happens here so that
-  -- uniqueness of the JSON event is enforced
-  (evInfo, eventId) <- insertEvent event
-  whatId <- insertDWhat Nothing dwhat eventId
+  let (labelWithTypes :: [LabelWithType]) = getLabelsWithType dwhat
+      (labelEpcs :: [LabelEPC]) = getLabel <$> labelWithTypes
+      (labelTypes :: [Maybe MU.LabelType]) = getLabelType <$> labelWithTypes
   labelIds' <- mapM insertLabel labelEpcs
   let labelIds = Schema.LabelId <$> labelIds'
+      labelIdWithTypes = zip labelTypes labelIds
   _whenId <- insertDWhen dwhen eventId
   _whyId <- insertDWhy dwhy eventId
   insertDWhere dwhere eventId
-  mapM_ (insertWhatLabel Nothing (Schema.WhatId whatId)) labelIds
-  mapM_ (insertLabelEvent Nothing eventId) labelIds
+  mapM_ (\(mLblType, lblId) -> insertWhatLabel mLblType (Schema.WhatId whatId) lblId) labelIdWithTypes
+  mapM_ (\(mLblType, lblId) -> insertLabelEvent mLblType eventId lblId) labelIdWithTypes
   pure (evInfo, eventId)
-
-
-insertAggEvent  :: (Member context '[HasDB],
-                    Member err     '[AsSqlError])
-                => AggregationEvent
-                -> AppM context err (EventInfo, Schema.EventId)
-insertAggEvent ev = runDb $ insertAggEventQuery ev
-
-insertAggEventQuery :: AggregationEvent
-                    -> DB context err (EventInfo, Schema.EventId)
-insertAggEventQuery
-  (AggregationEvent
-    foreignEventId
-    act
-    mParentLabel
-    labelEpcs
-    dwhen dwhy dwhere
-  ) = do
-  let
-      dwhat =  AggWhat $ AggregationDWhat act mParentLabel labelEpcs
-      event = Ev.Event Ev.AggregationEventT foreignEventId dwhat dwhen dwhy dwhere
-
-  -- insertEvent has to be the first thing that happens here so that
-  -- uniqueness of the JSON event is enforced
-  (evInfo, eventId) <- insertEvent event
-  whatId <- insertDWhat Nothing dwhat eventId
-  labelIds' <- mapM insertLabel labelEpcs
-  let labelIds = Schema.LabelId <$> labelIds'
-  mParentLabelId <- mapM insertLabel (IL . unParentLabel <$> mParentLabel)
-  _whenId <- insertDWhen dwhen eventId
-  _whyId <- insertDWhy dwhy eventId
-  insertDWhere dwhere eventId
-  mapM_ (insertWhatLabel Nothing (Schema.WhatId whatId)) labelIds
-  mapM_ (insertLabelEvent Nothing eventId) labelIds
-  when (isJust mParentLabelId) $ do
-    let Just parentLabelId' = mParentLabelId
-        parentLabelId = Schema.LabelId parentLabelId'
-    _ <- insertWhatLabel (Just MU.Parent) (Schema.WhatId whatId) parentLabelId
-    _ <- insertLabelEvent (Just MU.Parent) eventId parentLabelId
-    pure ()
-  pure (evInfo, eventId)
-
-
-insertTransactEvent :: (Member context '[HasDB],
-                        Member err     '[AsSqlError, AsServiceError])
-                    => TransactionEvent
-                    -> AppM context err (EventInfo, Schema.EventId)
-insertTransactEvent ev = runDb $ insertTransactEventQuery ev
-
-insertTransactEventQuery :: Member err '[AsServiceError]
-                         => TransactionEvent
-                         -> DB context err (EventInfo, Schema.EventId)
-insertTransactEventQuery
-  (TransactionEvent
-    foreignEventId
-    act
-    mParentLabel
-    bizTransactions
-    labelEpcs
-    dwhen dwhy dwhere
-  ) = do
-
-  let
-      dwhat =  TransactWhat $ TransactionDWhat act mParentLabel bizTransactions labelEpcs
-      event = Ev.Event Ev.TransactionEventT foreignEventId dwhat dwhen dwhy dwhere
-
-  -- insertEvent has to be the first thing that happens here so that
-  -- uniqueness of the JSON event is enforced
-  (evInfo, eventId) <- insertEvent event
-  whatId <- insertDWhat Nothing dwhat eventId
-  labelIds' <- mapM insertLabel labelEpcs
-  let labelIds = Schema.LabelId <$> labelIds'
-  mParentLabelId <- mapM insertLabel (IL . unParentLabel <$> mParentLabel)
-  _whenId <- insertDWhen dwhen eventId
-  _whyId <- insertDWhy dwhy eventId
-  insertDWhere dwhere eventId
-  mapM_ (insertWhatLabel Nothing (Schema.WhatId whatId)) labelIds
-  mapM_ (insertLabelEvent Nothing eventId) labelIds
-  when (isJust mParentLabelId) $ do
-    let Just parentLabelId' = mParentLabelId
-        parentLabelId = Schema.LabelId parentLabelId'
-    _ <- insertWhatLabel (Just MU.Parent) (Schema.WhatId whatId) parentLabelId
-    _ <- insertLabelEvent (Just MU.Parent) eventId parentLabelId
-    pure ()
-  pure (evInfo, eventId)
-
-
-insertTransfEvent :: (Member context '[HasDB],
-                      Member err     '[AsSqlError])
-                  => TransformationEvent
-                  -> AppM context err (EventInfo, Schema.EventId)
-insertTransfEvent ev = runDb $ insertTransfEventQuery ev
-
-insertTransfEventQuery :: TransformationEvent
-                       -> DB context err (EventInfo, Schema.EventId)
-insertTransfEventQuery
-  (TransformationEvent
-    foreignEventId
-    mTransfId
-    inputs
-    outputs
-    dwhen dwhy dwhere
-  ) = do
-  let
-      dwhat =  TransformWhat $ TransformationDWhat mTransfId inputs outputs
-      event = Ev.Event Ev.TransformationEventT foreignEventId dwhat dwhen dwhy dwhere
-
-  -- insertEvent has to be the first thing that happens here so that
-  -- uniqueness of the JSON event is enforced
-  (evInfo, eventId) <- insertEvent event
-  whatId <- insertDWhat Nothing dwhat eventId
-  inputLabelIds <- mapM (\(InputEPC i) -> insertLabel i) inputs
-  outputLabelIds <- mapM (\(OutputEPC o) -> insertLabel o) outputs
-  _whenId <- insertDWhen dwhen eventId
-  _whyId <- insertDWhy dwhy eventId
-  insertDWhere dwhere eventId
-  mapM_ (insertWhatLabel (Just MU.Input)  (Schema.WhatId whatId) . Schema.LabelId) inputLabelIds
-  mapM_ ((insertLabelEvent (Just MU.Input) eventId) . Schema.LabelId) inputLabelIds
-  mapM_ (insertWhatLabel (Just MU.Output) (Schema.WhatId whatId) . Schema.LabelId) outputLabelIds
-  mapM_ ((insertLabelEvent (Just MU.Output) eventId) . Schema.LabelId) outputLabelIds
-
-  pure (evInfo, eventId)
-
-
-
-
-
-
-
-
-{-
-Special cases:
-- Parent in Transact and AggWhat
-- Input and Output in TransformationEvent
-
- -}
 
 
 -- sendToBlockchain  :: (Member context '[HasDB],

--- a/projects/br_scs/src/Mirza/SupplyChain/PopulateUtils.hs
+++ b/projects/br_scs/src/Mirza/SupplyChain/PopulateUtils.hs
@@ -133,12 +133,7 @@ insertAndAuth scsUrl brUrl authToken locMap ht (entity:entities) = do
 insertEachEvent :: EachEvent ->  ClientM ()
 insertEachEvent (EachEvent [] _) = pure ()
 insertEachEvent (EachEvent entities ev) = do
-  (insertedEventInfo, _eventId) <- case _etype ev of
-          AggregationEventT -> SCSClient.insertAggEvent (fromJust $ mkAggEvent ev)
-          ObjectEventT -> SCSClient.insertObjectEvent (fromJust $ mkObjectEvent ev)
-          TransactionEventT -> SCSClient.insertTransactEvent (fromJust $ mkTransactEvent ev)
-          TransformationEventT -> SCSClient.insertTransfEvent (fromJust $ mkTransfEvent ev)
-
+  (insertedEventInfo, _eventId) <- SCSClient.insertGS1Event ev
   traverse_ (clientSignEvent insertedEventInfo) entities
 
 

--- a/projects/br_scs/src/Mirza/SupplyChain/Service.hs
+++ b/projects/br_scs/src/Mirza/SupplyChain/Service.hs
@@ -55,17 +55,14 @@ appHandlers =
        health
   -- Users
   :<|> versionInfo
-
--- Signatures
+  -- Signatures
   :<|> eventSign
--- Queries
+  -- Queries
   :<|> listEvents
   :<|> eventInfo
--- Event Registration
-  :<|> insertObjectEvent
-  :<|> insertAggEvent
-  :<|> insertTransactEvent
-  :<|> insertTransfEvent
+  -- Event Registration
+  :<|> insertGS1Event
+  -- UI
   :<|> listEventsPretty
 
 instance (KnownSymbol sym, HasSwagger sub) => HasSwagger (BasicAuth sym a :> sub) where

--- a/projects/br_scs/src/Mirza/SupplyChain/Service.hs
+++ b/projects/br_scs/src/Mirza/SupplyChain/Service.hs
@@ -10,8 +10,7 @@
 {-# LANGUAGE TypeOperators         #-}
 {-# OPTIONS_GHC -fno-warn-orphans  #-}
 
--- | Endpoint definitions go here. Most of the endpoint definitions are
--- light wrappers around functions in BeamQueries
+-- | Endpoint definitions go here
 module Mirza.SupplyChain.Service
   ( appHandlers
   , appMToHandler

--- a/projects/br_scs/src/Mirza/SupplyChain/Types.hs
+++ b/projects/br_scs/src/Mirza/SupplyChain/Types.hs
@@ -17,9 +17,6 @@ import           Mirza.Common.GS1BeamOrphans  (LabelType)
 import           Mirza.Common.Types           as Common
 
 import           Data.GS1.DWhat
-import           Data.GS1.DWhen
-import           Data.GS1.DWhere
-import           Data.GS1.DWhy
 import           Data.GS1.EPC                 as EPC
 import qualified Data.GS1.Event               as Ev
 import           Data.GS1.EventId             as EvId
@@ -49,9 +46,6 @@ import           Data.Text                    (Text)
 import           Katip                        as K
 
 import           Mirza.BusinessRegistry.Types (AsBRError (..), BRError)
-
-import           Data.Bifunctor               (Bifunctor (..))
-import           Data.Bitraversable           (Bitraversable (..))
 
 -- *****************************************************************************
 -- Context Types
@@ -83,135 +77,7 @@ $(makeLenses ''LabelWithType)
 
 deriving instance ToHttpApiData EventId
 
--- *****************************************************************************
--- Event Types
--- *****************************************************************************
--- TODO: The factory functions should probably be removed from here.
-
--- TODO: This should really be in GS1Combinators
-
 newtype EventOwner = EventOwner UserId deriving(Generic, Show, Eq, Read)
-
-data ObjectEvent = ObjectEvent {
-  obj_foreign_event_id :: Maybe EventId,
-  obj_act              :: Action,
-  obj_epc_list         :: [LabelEPC],
-  obj_when             :: DWhen,
-  obj_why              :: DWhy,
-  obj_where            :: DWhere
-} deriving (Show, Generic, Eq)
-$(deriveJSON defaultOptions ''ObjectEvent)
-instance ToSchema ObjectEvent
-
-mkObjectEvent :: Ev.Event -> Maybe ObjectEvent
-mkObjectEvent
-  (Ev.Event Ev.ObjectEventT
-    mEid
-    (ObjWhat (ObjectDWhat act epcList))
-    dwhen dwhy dwhere
-  ) = Just $ ObjectEvent mEid act epcList dwhen dwhy dwhere
-mkObjectEvent _ = Nothing
-
-fromObjectEvent :: ObjectEvent ->  Ev.Event
-fromObjectEvent (ObjectEvent mEid act epcList dwhen dwhy dwhere) =
-  Ev.Event
-    Ev.ObjectEventT
-    mEid
-    (ObjWhat (ObjectDWhat act epcList))
-    dwhen dwhy dwhere
-
--- XXX is it guaranteed to not have a ``recordTime``?
-data AggregationEvent = AggregationEvent {
-  agg_foreign_event_id :: Maybe EventId,
-  agg_act              :: Action,
-  agg_parent_label     :: Maybe ParentLabel,
-  agg_child_epc_list   :: [LabelEPC],
-  agg_when             :: DWhen,
-  agg_why              :: DWhy,
-  agg_where            :: DWhere
-} deriving (Show, Generic)
-$(deriveJSON defaultOptions ''AggregationEvent)
-instance ToSchema AggregationEvent
-
-mkAggEvent :: Ev.Event -> Maybe AggregationEvent
-mkAggEvent
-  (Ev.Event Ev.AggregationEventT
-    mEid
-    (AggWhat (AggregationDWhat act mParentLabel epcList))
-    dwhen dwhy dwhere
-  ) = Just $ AggregationEvent mEid act mParentLabel epcList dwhen dwhy dwhere
-mkAggEvent _ = Nothing
-
-fromAggEvent :: AggregationEvent ->  Ev.Event
-fromAggEvent (AggregationEvent mEid act mParentLabel epcList dwhen dwhy dwhere) =
-  Ev.Event
-    Ev.AggregationEventT
-    mEid
-    (AggWhat (AggregationDWhat act mParentLabel epcList))
-    dwhen dwhy dwhere
-
-data TransformationEvent = TransformationEvent {
-  transf_foreign_event_id  :: Maybe EventId,
-  transf_transformation_id :: Maybe TransformationId,
-  transf_input_list        :: [InputEPC],
-  transf_output_list       :: [OutputEPC],
-  transf_when              :: DWhen,
-  transf_why               :: DWhy,
-  transf_where             :: DWhere
-} deriving (Show, Generic)
-$(deriveJSON defaultOptions ''TransformationEvent)
-instance ToSchema TransformationEvent
-
-mkTransfEvent :: Ev.Event -> Maybe TransformationEvent
-mkTransfEvent
-  (Ev.Event Ev.TransformationEventT
-    mEid
-    (TransformWhat (TransformationDWhat mTransfId inputs outputs))
-    dwhen dwhy dwhere
-  ) = Just $ TransformationEvent mEid mTransfId inputs outputs dwhen dwhy dwhere
-mkTransfEvent _ = Nothing
-
-fromTransfEvent :: TransformationEvent ->  Ev.Event
-fromTransfEvent (TransformationEvent mEid mTransfId inputs outputs dwhen dwhy dwhere) =
-  Ev.Event
-    Ev.TransformationEventT
-    mEid
-    (TransformWhat (TransformationDWhat mTransfId inputs outputs))
-    dwhen dwhy dwhere
-
-data TransactionEvent = TransactionEvent {
-  transaction_foreign_event_id     :: Maybe EventId,
-  transaction_act                  :: Action,
-  transaction_parent_label         :: Maybe ParentLabel,
-  transaction_biz_transaction_list :: [BizTransaction],
-  transaction_epc_list             :: [LabelEPC],
-  transaction_when                 :: DWhen,
-  transaction_why                  :: DWhy,
-  transaction_where                :: DWhere
-} deriving (Show, Generic)
-$(deriveJSON defaultOptions ''TransactionEvent)
-instance ToSchema TransactionEvent
-
-mkTransactEvent :: Ev.Event -> Maybe TransactionEvent
-mkTransactEvent
-  (Ev.Event Ev.TransactionEventT
-    mEid
-    (TransactWhat (TransactionDWhat act mParentLabel bizTransactions epcList))
-    dwhen dwhy dwhere
-  ) = Just $
-      TransactionEvent
-        mEid act mParentLabel bizTransactions epcList
-        dwhen dwhy dwhere
-mkTransactEvent _ = Nothing
-
-fromTransactEvent :: TransactionEvent ->  Ev.Event
-fromTransactEvent (TransactionEvent mEid act mParentLabel bizTransactions epcList dwhen dwhy dwhere)
-  = Ev.Event
-      Ev.TransformationEventT
-      mEid
-      (TransactWhat (TransactionDWhat act mParentLabel bizTransactions epcList))
-      dwhen dwhy dwhere
-
 
 newtype SigningUser = SigningUser UserId deriving(Generic, Show, Eq, Read)
 

--- a/projects/br_scs/src/Mirza/SupplyChain/Types.hs
+++ b/projects/br_scs/src/Mirza/SupplyChain/Types.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TemplateHaskell            #-}

--- a/projects/br_scs/src/Mirza/SupplyChain/Types.hs
+++ b/projects/br_scs/src/Mirza/SupplyChain/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TemplateHaskell            #-}
@@ -12,6 +13,7 @@ module Mirza.SupplyChain.Types
   )
   where
 
+import           Mirza.Common.GS1BeamOrphans  (LabelType)
 import           Mirza.Common.Types           as Common
 
 import           Data.GS1.DWhat
@@ -48,6 +50,8 @@ import           Katip                        as K
 
 import           Mirza.BusinessRegistry.Types (AsBRError (..), BRError)
 
+import           Data.Bifunctor               (Bifunctor (..))
+import           Data.Bitraversable           (Bitraversable (..))
 
 -- *****************************************************************************
 -- Context Types
@@ -71,13 +75,20 @@ instance HasKatipContext SCSContext where
   katipContexts = scsKatipLogContexts
   katipNamespace = scsKatipNamespace
 
+data LabelWithType = LabelWithType
+  { getLabelType :: Maybe LabelType
+  , getLabel     :: LabelEPC
+  } deriving (Show, Eq)
+$(makeLenses ''LabelWithType)
+
+deriving instance ToHttpApiData EventId
+
 -- *****************************************************************************
 -- Event Types
 -- *****************************************************************************
 -- TODO: The factory functions should probably be removed from here.
 
 -- TODO: This should really be in GS1Combinators
-deriving instance ToHttpApiData EventId
 
 newtype EventOwner = EventOwner UserId deriving(Generic, Show, Eq, Read)
 

--- a/projects/br_scs/stack.yaml
+++ b/projects/br_scs/stack.yaml
@@ -14,8 +14,6 @@ extra-deps:
   commit: d7aca4d13b27235af47d522b5d093e567750628e
 - git: https://github.com/data61/GS1Combinators.git
   commit: 8fb62ddcd789a159041598fb8576e70e24217875
-- git: https://github.com/kapralVV/Unique.git
-  commit: 8b543fd9c9f9e3909875942098a47df19a68c9da  # Head on 2019-01-10
 - servant-flatten-0.2
 - hoist-error-0.2.1.0
 

--- a/projects/br_scs/test/Mirza/SupplyChain/Tests/Client.hs
+++ b/projects/br_scs/test/Mirza/SupplyChain/Tests/Client.hs
@@ -56,19 +56,19 @@ clientSpec = do
 
           step "Can insert Object events"
             -- TODO: Events need their EventId returned to user
-          http (insertObjectEvent dummyObject)
+          http (insertGS1Event dummyObjEvent)
             `shouldSatisfyIO` isRight
 
           step "Can insert Aggregation events"
-          http (insertAggEvent dummyAggregation)
+          http (insertGS1Event dummyAggEvent)
             `shouldSatisfyIO` isRight
 
           step "Can insert Transaction events"
-          http (insertTransactEvent dummyTransaction)
+          http (insertGS1Event dummyTransactEvent)
             `shouldSatisfyIO` isRight
 
           step "Can insert Transformation events"
-          http (insertTransfEvent dummyTransformation)
+          http (insertGS1Event dummyTransfEvent)
             `shouldSatisfyIO` isRight
 
   let _eventSignTests = testCaseSteps "eventSign" $ \step ->
@@ -104,7 +104,7 @@ clientSpec = do
           let keyId = fromRight (BRKeyId nil) keyIdResponse
 
           step "Inserting the object event"
-          objInsertionResponse <- httpSCS (insertObjectEvent dummyObject)
+          objInsertionResponse <- httpSCS (insertGS1Event dummyObjEvent)
           objInsertionResponse `shouldSatisfy` isRight
           let (EventInfo _ (Base64Octets to_sign_event) _, (Schema.EventId eventId)) = fromRight (error "Should be right") objInsertionResponse
 
@@ -179,7 +179,7 @@ clientSpec = do
           let keyIdReceiver = fromRight (BRKeyId nil) keyIdResponseReceiver
 
           step "Inserting the transaction event with the giver user"
-          transactInsertionResponse <- httpSCS (insertTransactEvent dummyTransaction)
+          transactInsertionResponse <- httpSCS (insertGS1Event dummyTransactEvent)
           transactInsertionResponse `shouldSatisfy` isRight
           let (_transactEvInfo@(EventInfo insertedTransactEvent (Base64Octets to_sign_transact_event) _), (Schema.EventId transactEvId)) =
                   fromRight (error "Should be right") transactInsertionResponse

--- a/projects/br_scs/test/Mirza/SupplyChain/Tests/Dummies.hs
+++ b/projects/br_scs/test/Mirza/SupplyChain/Tests/Dummies.hs
@@ -3,7 +3,6 @@
 -- in GS1Combinators
 module Mirza.SupplyChain.Tests.Dummies where
 
-import           Mirza.SupplyChain.Types
 import qualified Mirza.SupplyChain.Types as ST
 
 import           Data.GS1.DWhat
@@ -13,7 +12,6 @@ import           Data.GS1.DWhy
 import           Data.GS1.EPC
 import qualified Data.GS1.Event          as Ev
 
-import           Data.Maybe              (fromJust)
 import qualified Data.Text               as T
 import           Data.Time
 import           Data.UUID               (nil)
@@ -75,9 +73,6 @@ dummyObjectDWhat =
     Add
     dummyEpcList
 
-dummyObject :: ObjectEvent
-dummyObject = fromJust $ mkObjectEvent dummyObjEvent
-
 
 -- Aggregation Events
 dummyAggDWhat :: DWhat
@@ -97,9 +92,6 @@ dummyAggEvent =
     dummyDWhen
     dummyDWhy
     dummyDWhere
-
-dummyAggregation :: AggregationEvent
-dummyAggregation = fromJust $ mkAggEvent dummyAggEvent
 
 -- Transaction Events
 
@@ -122,10 +114,6 @@ dummyTransactEvent =
     dummyDWhy
     dummyDWhere
 
-dummyTransaction :: TransactionEvent
-dummyTransaction = fromJust $ mkTransactEvent dummyTransactEvent
-
-
 -- Transformation Events
 
 dummyTransfDWhat :: DWhat
@@ -147,9 +135,6 @@ dummyTransfEvent =
     dummyDWhen
     dummyDWhy
     dummyDWhere
-
-dummyTransformation :: TransformationEvent
-dummyTransformation = fromJust $ mkTransfEvent dummyTransfEvent
 
 -- Dimensions
 

--- a/projects/br_scs/test/Mirza/SupplyChain/Tests/Service.hs
+++ b/projects/br_scs/test/Mirza/SupplyChain/Tests/Service.hs
@@ -32,48 +32,48 @@ testServiceQueries = do
   describe "Object Event" $ do
     it "Insert Object Event" $ \scsContext -> do
       (evInfo, _) <- testAppM scsContext $
-        insertObjectEvent dummyObject
+        insertGS1Event dummyObjEvent
       (eventInfoEvent evInfo) `shouldBe` dummyObjEvent
 
     it "Should not allow duplicate Object events" $ \scsContext -> do
-      _res <- runAppM @_ @AppError scsContext $ insertObjectEvent dummyObject
-      res <- runAppM @_ @AppError scsContext $ insertObjectEvent dummyObject
+      _res <- runAppM @_ @AppError scsContext $ insertGS1Event dummyObjEvent
+      res <- runAppM @_ @AppError scsContext $ insertGS1Event dummyObjEvent
       res `shouldSatisfy` isLeft
 
   describe "Aggregation Event" $ do
     it "Insert Aggregation Event" $ \scsContext -> do
-      (evInfo, _) <- testAppM scsContext $ insertAggEvent dummyAggregation
+      (evInfo, _) <- testAppM scsContext $ insertGS1Event dummyAggEvent
       (eventInfoEvent evInfo) `shouldBe` dummyAggEvent
 
     it "Should not allow duplicate Aggregation events" $ \scsContext -> do
-      _res <- runAppM @_ @AppError scsContext $ insertAggEvent dummyAggregation
-      res <- runAppM @_ @AppError scsContext $ insertAggEvent dummyAggregation
+      _res <- runAppM @_ @AppError scsContext $ insertGS1Event dummyAggEvent
+      res <- runAppM @_ @AppError scsContext $ insertGS1Event dummyAggEvent
       res `shouldSatisfy` isLeft
 
   describe "Transformation Event" $ do
     it "Insert Transformation Event" $ \scsContext -> do
-      (evInfo, _) <- testAppM scsContext $ insertTransfEvent dummyTransformation
+      (evInfo, _) <- testAppM scsContext $ insertGS1Event dummyTransfEvent
       (eventInfoEvent evInfo) `shouldBe` dummyTransfEvent
 
     it "Should not allow duplicate Transformation events" $ \scsContext -> do
-      _res <- runAppM @_ @AppError scsContext $ insertTransfEvent dummyTransformation
-      res <- runAppM @_ @AppError scsContext $ insertTransfEvent dummyTransformation
+      _res <- runAppM @_ @AppError scsContext $ insertGS1Event dummyTransfEvent
+      res <- runAppM @_ @AppError scsContext $ insertGS1Event dummyTransfEvent
       res `shouldSatisfy` isLeft
 
   describe "Transaction Event" $ do
   -- The otherUserIds are being stubbed out here
     it "Insert Transaction Event" $ \scsContext -> do
-      (evInfo, _) <- testAppM scsContext $ insertTransactEvent dummyTransaction
+      (evInfo, _) <- testAppM scsContext $ insertGS1Event dummyTransactEvent
       (eventInfoEvent evInfo) `shouldBe` dummyTransactEvent
 
     it "Should not allow duplicate Transaction events" $ \scsContext -> do
-      _res <- runAppM @_ @AppError scsContext $ insertTransactEvent dummyTransaction
-      res <- runAppM @_ @AppError scsContext $ insertTransactEvent dummyTransaction
+      _res <- runAppM @_ @AppError scsContext $ insertGS1Event dummyTransactEvent
+      res <- runAppM @_ @AppError scsContext $ insertGS1Event dummyTransactEvent
       res `shouldSatisfy` isLeft
 
   describe "DWhere" $
     it "Insert and find DWhere" $ \scsContext -> do
       insertedDWhere <- testAppM scsContext $ do
-        (_, eventId) <- insertObjectEvent dummyObject
+        (_, eventId) <- insertGS1Event dummyObjEvent
         runDb $ findDWhere eventId
       insertedDWhere `shouldBe` Just dummyDWhere


### PR DESCRIPTION
- Removes separate definitions of different `Event`s.
- Collapses the insertion functions and endpoints into one endpoint which is agnostic of the event type.
Helps #435 